### PR TITLE
chore: Update ruby version matrix to include current ruby versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.7', '3.0', '3.1']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
As per https://github.com/openactive/models-ruby/pull/40#issuecomment-1514453971